### PR TITLE
Fix crash when viewing in-game documentation.

### DIFF
--- a/docs/geneticsresequenced/.content/blocks/anti_field_block.mdx
+++ b/docs/geneticsresequenced/.content/blocks/anti_field_block.mdx
@@ -12,5 +12,5 @@ The Anti-Field Block prevents certain Genes from working while nearby.
 The default radius of effect is 25 blocks, but this can be changed in the server config.
 
 It can disable the following Genes:
-- [Item Magnet](@geneticsresequenced:item_magnet)
-- [XP Magnet](@geneticsresequenced:xp_magnet)
+- [Item Magnet](../genes/player_only/item_magnet)
+- [XP Magnet](../genes/player_only/xp_magnet)

--- a/docs/geneticsresequenced/.content/blocks/machines/advanced_incubator.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/advanced_incubator.mdx
@@ -7,12 +7,12 @@ type: block
 
 <PrefabObtaining/>
 
-The **Advanced Incubator** is basically an upgraded version of the [Incubator](@geneticsresequenced:incubator), able to do everything it can and more.
+The **Advanced Incubator** is basically an upgraded version of the [Incubator](incubator), able to do everything it can and more.
 
-The Advanced Incubator has a **low temperature** mode, which can be toggled in its GUI. This is required for certain recipes, especially those involving [GMO Cells](@geneticsresequenced:gmo_cell).
+The Advanced Incubator has a **low temperature** mode, which can be toggled in its GUI. This is required for certain recipes, especially those involving [GMO Cells](../../items/gmo_cell).
 
-These recipes are much slower, and have a chance of failure. This chance is increased the more [Overclockers](@geneticsresequenced:overclocker) are installed.
+These recipes are much slower, and have a chance of failure. This chance is increased the more [Overclockers](../../items/overclocker) are installed.
 
-However, the chance of failure is *decreased* by inserting Chorus Fruit.
+However, the chance is increased by inserting Chorus Fruit.
 
 By hovering over the ingredients while in the GUI, you can see the exact chance of success, including any modifiers from Overclockers or Chorus Fruit.

--- a/docs/geneticsresequenced/.content/blocks/machines/blood_purifier.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/blood_purifier.mdx
@@ -7,6 +7,6 @@ type: block
 
 <PrefabObtaining/>
 
-The **Blood Purifier** is used to decontaminate [Syringes](@geneticsresequenced:syringe) and [Metal Syringes](@geneticsresequenced:metal_syringe).
+The **Blood Purifier** is used to decontaminate [Syringes](../../items/syringe) and [Metal Syringes](../../items/metal_syringe).
 
 Simply insert a contaminated Syringe into the input slot, and it will be purified and moved to the output slot.

--- a/docs/geneticsresequenced/.content/blocks/machines/cell_analyzer.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/cell_analyzer.mdx
@@ -7,6 +7,6 @@ type: block
 
 <PrefabObtaining/>
 
-The **Cell Analyzer** is used to convert [Organic Matter](@geneticsresequenced:organic_matter) into [Cells](@geneticsresequenced:cell) of the same entity type.
+The **Cell Analyzer** is used to convert [Organic Matter](../../items/organic_matter) into [Cells](../../items/cell) of the same entity type.
 
 A Pig's Organic Matter will produce Pig Cells, a Cow's Organic Matter will produce Cow Cells, and so on.

--- a/docs/geneticsresequenced/.content/blocks/machines/dna_decryptor.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/dna_decryptor.mdx
@@ -7,7 +7,7 @@ type: block
 
 <PrefabObtaining/>
 
-The **Dna Decryptor** is used to analyze [DNA Helices](@geneticsresequenced:dna_helix) to reveal the Genes they contain.
+The **Dna Decryptor** is used to analyze [DNA Helices](../../items/dna_helix) to reveal the Genes they contain.
 
 ## Usage
 

--- a/docs/geneticsresequenced/.content/blocks/machines/dna_extractor.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/dna_extractor.mdx
@@ -7,7 +7,7 @@ type: block
 
 <PrefabObtaining/>
 
-The **Dna Extractor** is used to convert [Cells](@geneticsresequenced:cell) and [GMO Cells](@geneticsresequenced:gmo_cell) into [DNA Helices](@geneticsresequenced:dna_helix).
+The **Dna Extractor** is used to convert [Cells](../../items/cell) and [GMO Cells](../../items/gmo_cell) into [DNA Helices](../../items/dna_helix).
 
 Regular Cells will be turned into Helices with unknown Genes, but still containing the entity type information.geneticsresequenced
 

--- a/docs/geneticsresequenced/.content/blocks/machines/plasmid_infuser.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/plasmid_infuser.mdx
@@ -7,7 +7,7 @@ type: block
 
 <PrefabObtaining/>
 
-The **Plasmid Infuser** is used to fill [Plasmids](@geneticsresequenced:plasmid) with Genes from [DNA Helices](@geneticsresequenced:dna_helix).
+The **Plasmid Infuser** is used to fill [Plasmids](../../items/plasmid) with Genes from [DNA Helices](../../items/dna_helix).
 
 Insert a Plasmid in the right slot, and DNA Helices in the left slot.
 
@@ -19,7 +19,7 @@ Helices with the Basic Gene will contribute 1 point, and Helices matching the Pl
 
 ## Example
 
-The [Eat Grass](@geneticsresequenced:genes/eat_grass) Gene requires 16 DNA Points.
+The [Eat Grass](../../../../../../../plasmid_infuser/eat_grass) Gene requires 16 DNA Points.
 
 First, put an empty Plasmid into the right slot.
 
@@ -27,4 +27,4 @@ Then, insert an Eat Grass DNA Helix into the left slot. This will set the Plasmi
 
 Each Eat Grass Helix inserted after that will contribute 2 points. Basic Helices will contribute 1 point.
 
-After you've inserted 16 points worth of Helices, the Plasmid will be completed and can be removed and used in the [Plasmid Injector](@geneticsresequenced:plasmid_injector).
+After you've inserted 16 points worth of Helices, the Plasmid will be completed and can be removed and used in the [Plasmid Injector](plasmid_injector).

--- a/docs/geneticsresequenced/.content/blocks/machines/plasmid_injector.mdx
+++ b/docs/geneticsresequenced/.content/blocks/machines/plasmid_injector.mdx
@@ -7,6 +7,6 @@ type: block
 
 <PrefabObtaining/>
 
-The **Plasmid Injector** is used to insert completed [Plasmids](@geneticsresequenced:plasmid) into decontaminated [Syringes](@geneticsresequenced:syringe) and [Metal Syringes](@geneticsresequenced:metal_syringe).
+The **Plasmid Injector** is used to insert completed [Plasmids](../../items/plasmid) into decontaminated [Syringes](../../items/syringe) and [Metal Syringes](../../items/metal_syringe).
 
 This allows you to give yourself or others the Genes contained by the Plasmid. Syringes can have multiple Plasmids injected into them, allowing for adding multiple Genes in one go.

--- a/docs/geneticsresequenced/.content/genes/basic.mdx
+++ b/docs/geneticsresequenced/.content/genes/basic.mdx
@@ -5,7 +5,7 @@ icon: geneticsresequenced:dna_helix
 type: gene
 ---
 
-The **Basic** Gene is a filler Gene, and cannot be injected into anything. Its sole use is for DNA Points in the [Plasmid Infuser](@geneticsresequenced:plasmid_infuser).
+The **Basic** Gene is a filler Gene, and cannot be injected into anything. Its sole use is for DNA Points in the [Plasmid Infuser](../blocks/machines/plasmid_infuser).
 
 ## Obtaining
 

--- a/docs/geneticsresequenced/.content/genes/ender_dragon_health.mdx
+++ b/docs/geneticsresequenced/.content/genes/ender_dragon_health.mdx
@@ -5,7 +5,7 @@ icon: geneticsresequenced:dna_helix
 type: gene
 ---
 
-The **Ender Dragon Health** Gene allows entities to offload incoming damage onto a held [Dragon Health Crystal](@geneticsresequenced:dragon_health_crystal).
+The **Ender Dragon Health** Gene allows entities to offload incoming damage onto a held [Dragon Health Crystal](../items/dragon_health_crystal).
 
 ## Obtaining
 

--- a/docs/geneticsresequenced/.content/genes/negative/blindness.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/blindness.mdx
@@ -9,4 +9,4 @@ The **Blindness** Gene gives entities the Blindness potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Night Vision](@geneticsresequenced:night_vision) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Night Vision](../potion/night_vision) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/cringe.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/cringe.mdx
@@ -9,7 +9,7 @@ The **Cwinge** Gene makes it so dat aww da pwayew's outgoing chat messagies awe 
 
 Additionawwy, if nyot disabwed in da config, it wiww awso change youw set wanguage to WOWCAT.
 
-Has a speciaw intewaction wif da [Eat Gwass](@geneticsresequenced:eat_grass) Gene…
+Has a speciaw intewaction wif da [Eat Gwass](../player_only/eat_grass) Gene…
 
 ## Obtaining
 

--- a/docs/geneticsresequenced/.content/genes/negative/cursed.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/cursed.mdx
@@ -9,4 +9,4 @@ The **Cursed** Gene gives entities the Cursed potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Luck](@geneticsresequenced:luck) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Luck](../potion/luck) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/flambe.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/flambe.mdx
@@ -9,4 +9,4 @@ The **Flambe** Gene will constantly light the entity on fire.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Fire Proof](@geneticsresequenced:fire_proof) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Fire Proof](../fire_proof) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/hunger.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/hunger.mdx
@@ -9,4 +9,4 @@ The **Hunger** Gene gives entities the Hunger potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [No Hunger](@geneticsresequenced:no_hunger) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [No Hunger](../player_only/no_hunger) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/mining_fatigue.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/mining_fatigue.mdx
@@ -9,4 +9,4 @@ The **Mining Fatigue** Gene gives entities the Mining Fatigue potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Haste](@geneticsresequenced:haste) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Haste](../potion/haste) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/nausea.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/nausea.mdx
@@ -9,4 +9,4 @@ The **Nausea** Gene gives entities the Nausea potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Milky](@geneticsresequenced:milky), [Meaty](@geneticsresequenced:meaty), or [Lay Eggs](@geneticsresequenced:lay_eggs) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Milky](../milky), [Meaty](../meaty), or [Lay Eggs](../../../../../../../nausea) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/poison.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/poison.mdx
@@ -9,6 +9,6 @@ The **Poison** Gene gives entities the Poison potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Poison Immunity](@geneticsresequenced:poison_immunity) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Poison Immunity](../poison_immunity) DNA Helix in an [Incubator](../../blocks/machines/incubator).
 
-The Poison IV Helix can be obtained by combining a Potion of Viral Agents with a [Wither Hit](@geneticsresequenced:wither_hit) DNA Helix in the Incubator.
+The Poison IV Helix can be obtained by combining a Potion of Viral Agents with a [Wither Hit](../wither_hit) DNA Helix in the Incubator.

--- a/docs/geneticsresequenced/.content/genes/negative/slowness.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/slowness.mdx
@@ -9,6 +9,6 @@ The **Slowness** Gene gives entities the Slowness potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Speed](@geneticsresequenced:speed) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Speed](../potion/speed) DNA Helix in an [Incubator](../../blocks/machines/incubator).
 
 Slowness IV requires Speed II, and Slowness VI requires Speed IV.

--- a/docs/geneticsresequenced/.content/genes/negative/weakness.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/weakness.mdx
@@ -9,4 +9,4 @@ The **Weakness** Gene gives entities the Weakness potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Strength](@geneticsresequenced:strength) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Strength](../potion/strength) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/negative/wither.mdx
+++ b/docs/geneticsresequenced/.content/genes/negative/wither.mdx
@@ -9,4 +9,4 @@ The **Wither** Gene gives entities the Wither potion effect.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Wither Proof](@geneticsresequenced:wither_proof) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Wither Proof](../wither_proof) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/plagues/black_death.mdx
+++ b/docs/geneticsresequenced/.content/genes/plagues/black_death.mdx
@@ -9,4 +9,4 @@ The **Black Death** Gene kills everything.
 
 ## Obtaining
 
-Get it by combining every (non-disabled) negative Gene in an [Incubator](@geneticsresequenced:incubator) with a [Potion of Viral Agents](@geneticsresequenced:viral_agents).
+Get it by combining every (non-disabled) negative Gene in an [Incubator](../../blocks/machines/incubator) with a [Potion of Viral Agents](../../items/potion/viral_agents).

--- a/docs/geneticsresequenced/.content/genes/plagues/gray_death.mdx
+++ b/docs/geneticsresequenced/.content/genes/plagues/gray_death.mdx
@@ -9,4 +9,4 @@ The **Gray Death** Gene kills ageable mobs.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Resistance](@geneticsresequenced:resistance) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Resistance](../potion/resistance) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/plagues/green_death.mdx
+++ b/docs/geneticsresequenced/.content/genes/plagues/green_death.mdx
@@ -9,4 +9,4 @@ The **Green Death** Gene kills Creepers.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Scare Creepers](@geneticsresequenced:scare_creepers) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Scare Creepers](../scare_creepers) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/plagues/un_undeath.mdx
+++ b/docs/geneticsresequenced/.content/genes/plagues/un_undeath.mdx
@@ -9,4 +9,4 @@ The **Un-Undeath** Gene kills the undead.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Scare Skeletons](@geneticsresequenced:scare_skeletons) or [Scare Zombies](@geneticsresequenced:scare_zombies) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Scare Skeletons](../scare_skeletons) or [Scare Zombies](../scare_zombies) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/plagues/white_death.mdx
+++ b/docs/geneticsresequenced/.content/genes/plagues/white_death.mdx
@@ -9,4 +9,4 @@ The **Green Death** Gene kills Monsters.
 
 ## Obtaining
 
-Get the Gene by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Dragon's Breath](@geneticsresequenced:dragons_breath) DNA Helix in an [Incubator](@geneticsresequenced:incubator).
+Get the Gene by combining a [Potion of Viral Agents](../../items/potion/viral_agents) with a [Dragon's Breath](../../../../../../../white_death) DNA Helix in an [Incubator](../../blocks/machines/incubator).

--- a/docs/geneticsresequenced/.content/genes/player_only/eat_grass.mdx
+++ b/docs/geneticsresequenced/.content/genes/player_only/eat_grass.mdx
@@ -9,7 +9,7 @@ The **Eat Grass** Gene allows the player to right-click Grass Blocks with an emp
 
 Grass Blocks and Mycelium will be turned into Dirt. Nylium of both varieties will be turned into Netherrack.
 
-Eating grass also has some unique interactions with the [Wooly](@geneticsresequenced:wooly) and [Cringe](@geneticsresequenced:cringe) Genes...
+Eating grass also has some unique interactions with the [Wooly](../wooly) and [Cringe](../negative/cringe) Genes...
 
 ## Obtaining
 

--- a/docs/geneticsresequenced/.content/genes/player_only/item_magnet.mdx
+++ b/docs/geneticsresequenced/.content/genes/player_only/item_magnet.mdx
@@ -9,7 +9,7 @@ The **Item Magnet** Gene will cause item entities to be picked up from a greater
 
 By default, every 10 ticks it searches for item entities in an 8 block radius around the player, and tries to pick them up. Both of these values can be changed in the server config.
 
-It can be disabled by the [Anti-Field Block](@geneticsresequenced:anti_field_block), or by sneaking.
+It can be disabled by the [Anti-Field Block](../../blocks/anti_field_block), or by sneaking.
 
 ## Obtaining
 

--- a/docs/geneticsresequenced/.content/genes/player_only/xp_magnet.mdx
+++ b/docs/geneticsresequenced/.content/genes/player_only/xp_magnet.mdx
@@ -9,7 +9,7 @@ The **XP Magnet** Gene will cause Experience Orbs to be picked up from a greater
 
 By default, every 10 ticks it searches for Experience Orbs in an 8 block radius around the player, and tries to pick them up. Both of these values can be changed in the server config.
 
-It can be disabled by the [Anti-Field Block](@geneticsresequenced:anti_field_block), or by sneaking.
+It can be disabled by the [Anti-Field Block](../../blocks/anti_field_block), or by sneaking.
 
 ## Obtaining
 

--- a/docs/geneticsresequenced/.content/items/anti_field_orb.mdx
+++ b/docs/geneticsresequenced/.content/items/anti_field_orb.mdx
@@ -12,5 +12,5 @@ The **Anti-Field Orb** can be toggled to disable certain Genes while held in you
 Simply right-click the Orb to toggle it on or off.
 
 It can disable the following Genes:
-- [Item Magnet](@geneticsresequenced:item_magnet)
-- [XP Magnet](@geneticsresequenced:xp_magnet)
+- [Item Magnet](../genes/player_only/item_magnet)
+- [XP Magnet](../genes/player_only/xp_magnet)

--- a/docs/geneticsresequenced/.content/items/anti_plasmid.mdx
+++ b/docs/geneticsresequenced/.content/items/anti_plasmid.mdx
@@ -9,6 +9,6 @@ type: item
 
 The **Anti-Plasmid** is used to remove unwanted Genes from a host.
 
-Craft an empty Anti-Plasmid with any completed regular [Plasmid](@geneticsresequenced:plasmid) to get an Anti-Plasmid of the same Gene.
+Craft an empty Anti-Plasmid with any completed regular [Plasmid](plasmid) to get an Anti-Plasmid of the same Gene.
 
-Put it through the [Plasmid Injector](@geneticsresequenced:plasmid_injector) the same way as a regular Plasmid, and then when it's injected into the host, it will remove the Gene from them if they have it.
+Put it through the [Plasmid Injector](../blocks/machines/plasmid_injector) the same way as a regular Plasmid, and then when it's injected into the host, it will remove the Gene from them if they have it.

--- a/docs/geneticsresequenced/.content/items/cell.mdx
+++ b/docs/geneticsresequenced/.content/items/cell.mdx
@@ -7,4 +7,4 @@ type: item
 
 **Cells** contain information about an entity type.
 
-They can be converted into [DNA Helices](@geneticsresequenced:dna_helix) in the [DNA Extractor](@geneticsresequenced:dna_extractor). These Helices will have an unknown Gene, requiring further processing.
+They can be converted into [DNA Helices](dna_helix) in the [DNA Extractor](../blocks/machines/dna_extractor). These Helices will have an unknown Gene, requiring further processing.

--- a/docs/geneticsresequenced/.content/items/dna_helix.mdx
+++ b/docs/geneticsresequenced/.content/items/dna_helix.mdx
@@ -5,11 +5,11 @@ related_items: [geneticsresequenced:dna_helix]
 type: item
 ---
 
-**DNA Helices** each contain a specific Gene. By default this Gene is unknown, and must be identified using a [Gene Decryptor](@geneticsresequenced:gene_decryptor).
+**DNA Helices** each contain a specific Gene. By default this Gene is unknown, and must be identified using a [Gene Decryptor](../../../../../../dna_helix).
 
 Each entity type has a specific set of possible Genes that they can provide. These Genes are also weighted, so some Genes are more likely to be obtained than others.
 
-You can check what Genes a mob can provide using the [Gene Checker](@geneticsresequenced:gene_checker), using [EMI](https://www.curseforge.com/minecraft/mc-mods/emi), or checking the [mod's datapack](https://github.com/Berry-Club/Genetics-Resequenced/tree/NeoForge-1.21/src/generated/resources/data/minecraft/geneticsresequenced/entity_genes).
+You can check what Genes a mob can provide using the [Gene Checker](gene_checker), using [EMI](https://www.curseforge.com/minecraft/mc-mods/emi), or checking the [mod's datapack](https://github.com/Berry-Club/Genetics-Resequenced/tree/NeoForge-1.21/src/generated/resources/data/minecraft/geneticsresequenced/entity_genes).
 
 For example, a Cow has the following Gene weights:
 - Basic: 5
@@ -18,4 +18,4 @@ For example, a Cow has the following Gene weights:
 
 These weights add up to 12. That means decrypting a Cow DNA Helix has a 5/12 chance of having the Basic Gene, a 3/12 chance of having the Eat Grass Gene, and a 4/12 chance of having the Milky Gene.
 
-Once a DNA Helix has been decrypted, it must be inserted into a [Plasmid](@geneticsresequenced:plasmid) in the [Plasmid Infuser](@geneticsresequenced:plasmid_infuser).
+Once a DNA Helix has been decrypted, it must be inserted into a [Plasmid](plasmid) in the [Plasmid Infuser](plasmid_infuser).

--- a/docs/geneticsresequenced/.content/items/dragon_health_crystal.mdx
+++ b/docs/geneticsresequenced/.content/items/dragon_health_crystal.mdx
@@ -7,7 +7,7 @@ type: item
 
 <PrefabObtaining/>
 
-The **Dragon Health Crystal** works in tandem with the [Ender Dragon Health](@geneticsresequenced:genes/ender_dragon_health) Gene to negate incoming damage.
+The **Dragon Health Crystal** works in tandem with the [Ender Dragon Health](../../../../../../dragon_health_crystal/ender_dragon_health) Gene to negate incoming damage.
 
 While holding the Crystal in your inventory and possessing the Gene, any damage that would be dealt to the entity will instead be dealt to the Crystal.
 

--- a/docs/geneticsresequenced/.content/items/gmo_cell.mdx
+++ b/docs/geneticsresequenced/.content/items/gmo_cell.mdx
@@ -9,6 +9,6 @@ type: item
 
 Each GMO Cell has its own recipe, allowing you to skip the grinding process of randomly getting a specific Gene normally.
 
-For example, a [Potion of Mutation](@geneticsresequenced:potion_of_mutation) combined with a [Netherrack Pickaxe](@Netherite_Pickaxe) can be combined in a **low temperature** [Advanced Incubator](@geneticsresequenced:advanced_incubator) to have a chance of getting the [Haste II](@geneticsresequenced:genes/haste_ii) Gene.
+For example, a [Potion of Mutation](../../../../../../gmo_cell) combined with a [Netherrack Pickaxe](@Netherite_Pickaxe) can be combined in a **low temperature** [Advanced Incubator](../blocks/machines/advanced_incubator) to have a chance of getting the [Haste II](../../../../../../gmo_cell/haste_ii) Gene.
 
-For a full list of GMO recipes you can either use [EMI](https://www.curseforge.com/minecraft/mc-mods/emi), or check the [default GMO recipes]($players/default_gmo_recipes) page.
+For a full list of GMO recipes you can either use [EMI](https://www.curseforge.com/minecraft/mc-mods/emi), or check the [mod's source code](https://github.com/Berry-Club/Genetics-Resequenced/tree/NeoForge-1.21/src/generated/resources/data/geneticsresequenced/recipe/incubator/gmo).

--- a/docs/geneticsresequenced/.content/items/metal_syringe.mdx
+++ b/docs/geneticsresequenced/.content/items/metal_syringe.mdx
@@ -11,9 +11,9 @@ The *Metal *Syringe** is used to hold blood, which is the primary medium for inj
 
 Hold right-click to use the syringe, extracting blood from the entity you're looking at. While holding a filled Metal Syringe, the blood's owner will glow through walls.
 
-It will be contaminated, requiring decontamination in a [Blood Purifier](@geneticsresequenced:blood_purifier) before it can be used.
+It will be contaminated, requiring decontamination in a [Blood Purifier](../blocks/machines/blood_purifier) before it can be used.
 
-Then, place it into a [Plasmid Injector](@geneticsresequenced:plasmid_injector) to inject completed [Plasmids](@geneticsresequenced:plasmid) into it.
+Then, place it into a [Plasmid Injector](../blocks/machines/plasmid_injector) to inject completed [Plasmids](plasmid) into it.
 
 Each completed Plasmid contains a Gene, which will be given to the blood's owner upon re-injecting the blood. You can have as many Plasmids injected into the Syringe as you like.
 

--- a/docs/geneticsresequenced/.content/items/organic_matter.mdx
+++ b/docs/geneticsresequenced/.content/items/organic_matter.mdx
@@ -5,6 +5,6 @@ related_items: [geneticsresequenced:organic_matter]
 type: item
 ---
 
-**Organic Matter** contains information about an entity type. It can be acquired using the [Scraper](@geneticsresequenced:scraper).
+**Organic Matter** contains information about an entity type. It can be acquired using the [Scraper](scraper).
 
-It can be converted into [Cells](@geneticsresequenced:cell) in the [Cell Analyzer](@geneticsresequenced:cell_analyzer).
+It can be converted into [Cells](cell) in the [Cell Analyzer](cell_analyzer).

--- a/docs/geneticsresequenced/.content/items/plasmid.mdx
+++ b/docs/geneticsresequenced/.content/items/plasmid.mdx
@@ -11,7 +11,7 @@ The **Plasmid** is a vessel for carrying a Gene, to be injected into a host's bl
 
 ## Filling
 
-Place the Plasmid in the right slot of a [Plasmid Infuser](@geneticsresequenced:plasmid_infuser). Then, place a decrypted [DNA Helix](@geneticsresequenced:dna_helix) in the left slot.
+Place the Plasmid in the right slot of a [Plasmid Infuser](../blocks/machines/plasmid_infuser). Then, place a decrypted [DNA Helix](dna_helix) in the left slot.
 
 Each Gene has a specific amount of DNA Points required for the Plasmid to be infused with that Gene.
 
@@ -21,4 +21,4 @@ Helices with the Basic Gene will contribute 1 point, and Helices matching the Pl
 
 ## Using
 
-A completed Plasmid can be inserted into a filled [Syringe](@geneticsresequenced:syringe) or [Metal Syringe](@geneticsresequenced:metal_syringe) in the [Plasmid Injector](@geneticsresequenced:plasmid_injector), and then will give the Gene when injected into the host.
+A completed Plasmid can be inserted into a filled [Syringe](syringe) or [Metal Syringe](metal_syringe) in the [Plasmid Injector](../blocks/machines/plasmid_injector), and then will give the Gene when injected into the host.

--- a/docs/geneticsresequenced/.content/items/potion/mutation.mdx
+++ b/docs/geneticsresequenced/.content/items/potion/mutation.mdx
@@ -4,22 +4,22 @@ id: geneticsresequenced:mutation
 type: item
 ---
 
-**Potions of Mutation** are created by combining a [Potion of Cell Growth](@geneticsresequenced:potion_of_cell_growth) with a Fermented Spider Eye in a Brewing Stand.
+**Potions of Mutation** are created by combining a [Potion of Cell Growth](potion_of_cell_growth) with a Fermented Spider Eye in a Brewing Stand.
 
-Brewing a Chorus Fruit into one will create a [Potion of Viral Agents](@geneticsresequenced:potion_of_cell_growth).
+Brewing a Chorus Fruit into one will create a [Potion of Viral Agents](potion_of_cell_growth).
 
 ## GMO Cell Incubating
 
-Like PCGs, Potions of Mutation are also used to create [GMO Cells](@geneticsresequenced:gmo_cell). Each GMO Cell has its own recipe, which has a chance of failure.
+Like PCGs, Potions of Mutation are also used to create [GMO Cells](../gmo_cell). Each GMO Cell has its own recipe, which has a chance of failure.
 
-Also like the PCG, you first have to set an entity type by combining it with a [Cell](@geneticsresequenced:cell) of the desired type in an [Incubator](@geneticsresequenced:incubator).
+Also like the PCG, you first have to set an entity type by combining it with a [Cell](../cell) of the desired type in an [Incubator](../../blocks/machines/incubator).
 
 Then, combine the Potion of Mutation in the Incubator with the required ingredients for the desired GMO Cell. If successful, it will produce the GMO Cell.
 
-Then, combine that Potion of Mutation with the appropriate item per the recipe in the [Advanced Incubator](@geneticsresequenced:advanced_incubator) **at LOW TEMPERATURE** to have a chance of producing the GMO Cell.
+Then, combine that Potion of Mutation with the appropriate item per the recipe in the [Advanced Incubator](../../blocks/machines/advanced_incubator) **at LOW TEMPERATURE** to have a chance of producing the GMO Cell.
 
 ## Example
 
 Generally, this is the only way to get Mutation Genes, which are usually more powerful.
 
-For example, combining an Ender Dragon PoM with an Elytra has a base 55% chance of producing a [Flight](@geneticsresequenced:flight) GMO Cell.
+For example, combining an Ender Dragon PoM with an Elytra has a base 55% chance of producing a [Flight](../../genes/player_only/flight) GMO Cell.

--- a/docs/geneticsresequenced/.content/items/potion/organic_substrate.mdx
+++ b/docs/geneticsresequenced/.content/items/potion/organic_substrate.mdx
@@ -6,6 +6,6 @@ type: item
 
 **Organic Substrate** is a potion used in certain recipes.
 
-It can be combined with Basic [Dna Helices](@geneticsresequenced:dna_helix) in the [Incubator](@geneticsresequenced:incubator) to create [Potions of Cell Growth](@geneticsresequenced:potion_of_cell_growth).
+It can be combined with Basic [Dna Helices](../dna_helix) in the [Incubator](../../blocks/machines/incubator) to create [Potions of Cell Growth](potion_of_cell_growth).
 
-Alternatively, it can be combined with [Cells](@geneticsresequenced:cell) in the Incubator to duplicate them, making a new identical Cell for each Substrate.
+Alternatively, it can be combined with [Cells](../cell) in the Incubator to duplicate them, making a new identical Cell for each Substrate.

--- a/docs/geneticsresequenced/.content/items/potion/panacea.mdx
+++ b/docs/geneticsresequenced/.content/items/potion/panacea.mdx
@@ -4,6 +4,6 @@ id: geneticsresequenced:panacea
 type: item
 ---
 
-**Panacea** can be crafted by combining a [Potion of Viral Agents](@geneticsresequenced:viral_agents) with a [Regeneration](@geneticsresequenced:regeneration) Helix.
+**Panacea** can be crafted by combining a [Potion of Viral Agents](viral_agents) with a [Regeneration](../../genes/potion/regeneration) Helix.
 
 When consumed, it instantly removes all harmful status effects and all negative Genes.

--- a/docs/geneticsresequenced/.content/items/potion/potion_of_cell_growth.mdx
+++ b/docs/geneticsresequenced/.content/items/potion/potion_of_cell_growth.mdx
@@ -4,21 +4,21 @@ id: geneticsresequenced:potion_of_cell_growth
 type: item
 ---
 
-**Potions of Cell Growth** are created by combining a Basic [DNA Helix](@geneticsresequenced:dna_helix) into some [Organic Substrate](@geneticsresequenced:organic_substrate) in a Brewing Stand.
+**Potions of Cell Growth** are created by combining a Basic [DNA Helix](../dna_helix) into some [Organic Substrate](organic_substrate) in a Brewing Stand.
 
-It can be combined with a Fermented Spider Eye in a Brewing Stand to create a [Potion of Mutation](@geneticsresequenced:potion_of_mutation).
+It can be combined with a Fermented Spider Eye in a Brewing Stand to create a [Potion of Mutation](../../../../../../../potion_of_cell_growth).
 
 ## GMO Cell Incubating
 
-PCGs are also used to create [GMO Cells](@geneticsresequenced:gmo_cell). Each GMO Cell has its own recipe, which has a chance of failure.
+PCGs are also used to create [GMO Cells](../gmo_cell). Each GMO Cell has its own recipe, which has a chance of failure.
 
-First, the PCG has to have its entity type set. Combine it in an [Incubator](@geneticsresequenced:incubator) with a [Cell](@geneticsresequenced:cell) of the desired type, and it will gain the Cell's entity type.
+First, the PCG has to have its entity type set. Combine it in an [Incubator](../../blocks/machines/incubator) with a [Cell](../cell) of the desired type, and it will gain the Cell's entity type.
 
 Then, combine the PCG in the Incubator with the required ingredients for the desired GMO Cell. If successful, it will produce the GMO Cell.
 
-Then, combine that PCG with the appropriate item per the recipe in the [Advanced Incubator](@geneticsresequenced:advanced_incubator) **at LOW TEMPERATURE** to have a chance of producing the GMO Cell.geneticsresequenced
+Then, combine that PCG with the appropriate item per the recipe in the [Advanced Incubator](../../blocks/machines/advanced_incubator) **at LOW TEMPERATURE** to have a chance of producing the GMO Cell.geneticsresequenced
 
-[Overclockers](@geneticsresequenced:overclocker) decrease the chance for success, but Chorus Fruits increase it.
+[Overclockers](../overclocker) decrease the chance for success, but Chorus Fruits increase it.
 
 ## Example
 

--- a/docs/geneticsresequenced/.content/items/potion/viral_agents.mdx
+++ b/docs/geneticsresequenced/.content/items/potion/viral_agents.mdx
@@ -4,6 +4,6 @@ id: geneticsresequenced:viral_agents
 type: item
 ---
 
-**Potions of Viral Agents** are used to craft virus Genes, which are basically just negative Genes. Stuff that's detrimental to have, like [Weakness](@geneticsresequenced:weakness).
+**Potions of Viral Agents** are used to craft virus Genes, which are basically just negative Genes. Stuff that's detrimental to have, like [Weakness](../../genes/negative/weakness).
 
-It can also be crafted into [Panacea](@geneticsresequenced:panacea), [Potions of Zombify Villager](@geneticsresequenced:zombify_villager), and a syringe of [Black Death](@geneticsresequenced:black_death).
+It can also be crafted into [Panacea](panacea), [Potions of Zombify Villager](../../../../../../../viral_agents), and a syringe of [Black Death](../../genes/plagues/black_death).

--- a/docs/geneticsresequenced/.content/items/scraper.mdx
+++ b/docs/geneticsresequenced/.content/items/scraper.mdx
@@ -7,9 +7,9 @@ type: item
 
 <PrefabObtaining/>
 
-The **Scraper** is used to acquire [Organic Matter](@geneticsresequenced:organic_matter) from mobs.
+The **Scraper** is used to acquire [Organic Matter](organic_matter) from mobs.
 
-Right-click the Scraper on a mob to scrape some Organic Matter off of it, damaging them in the process. The [Delicate Touch](@geneticsresequenced:delicate_touch) Enchantment can be applied, negating the damage dealt.
+Right-click the Scraper on a mob to scrape some Organic Matter off of it, damaging them in the process. The [Delicate Touch](../../../../../../scraper) Enchantment can be applied, negating the damage dealt.
 
 The Organic Matter you acquire will contain the information about the entity type you scraped it from.
 

--- a/docs/geneticsresequenced/.content/items/syringe.mdx
+++ b/docs/geneticsresequenced/.content/items/syringe.mdx
@@ -11,9 +11,9 @@ The **Syringe** is used to hold blood, which is the primary medium for injecting
 
 Hold right-click to use the syringe, extracting some of your own blood.
 
-It will be contaminated, requiring decontamination in a [Blood Purifier](@geneticsresequenced:blood_purifier) before it can be used.
+It will be contaminated, requiring decontamination in a [Blood Purifier](../blocks/machines/blood_purifier) before it can be used.
 
-Then, place it into a [Plasmid Injector](@geneticsresequenced:plasmid_injector) to inject completed [Plasmids](@geneticsresequenced:plasmid) into it.
+Then, place it into a [Plasmid Injector](../blocks/machines/plasmid_injector) to inject completed [Plasmids](plasmid) into it.
 
 Each completed Plasmid contains a Gene, which will be given to you upon re-injecting the blood. You can have as many Plasmids injected into the Syringe as you like.
 

--- a/docs/geneticsresequenced/players/advanced.mdx
+++ b/docs/geneticsresequenced/players/advanced.mdx
@@ -4,13 +4,13 @@
 
 When two mobs breed, their offspring has a chance to inherit Genes from their parents. The chance is 50% per parent that has the Gene.
 
-This can have interesting interactions with Genes like [Bountiful](@geneticsresequenced:bountiful)!
+This can have interesting interactions with Genes like [Oozing](../.content/genes/negative/oozing)!
 
 ## Gene Requirements
 
 Certain Genes may require other Genes be present in the host. If that Gene is not present, the dependent Gene will fade away.
 
-For example, the [Photosynthesis](@geneticsresequenced:photosynthesis) Gene requires [Eat Grass](@geneticsresequenced:eat_grass) and [Thorns](@geneticsresequenced:thorns).
+For example, the [Photosynthesis](../.content/genes/player_only/photosynthesis) Gene requires [Eat Grass](../.content/genes/player_only/eat_grass) and [Thorns](../.content/genes/thorns).
 
 The only way to see Gene requirements currently is to check the DNA Helix's information recipes in [EMI](https://www.curseforge.com/minecraft/mc-mods/emi), or by looking at the source code [here](https://github.com/Berry-Club/Genetics-Resequenced/tree/NeoForge-1.21/src/generated/resources/data/geneticsresequenced/geneticsresequenced/gene_requirements).
 
@@ -18,6 +18,6 @@ A way in-game will be made eventually. Probably.
 
 ## Mutation Genes
 
-Mutation Genes are especially strong Genes, that are generally acquired through special means, such as [GMO Cells](@geneticsresequenced:gmo_cell).
+Mutation Genes are especially strong Genes, that are generally acquired through special means, such as [GMO Cells](../.content/items/gmo_cell).
 
 Additionally, mutation Genes often have prerequesites.

--- a/docs/geneticsresequenced/players/getting_started.mdx
+++ b/docs/geneticsresequenced/players/getting_started.mdx
@@ -4,27 +4,27 @@
 
 **Genes** can be taken from mobs to harness their abilities.
 
-For example, Sheep have the [Wooly](@geneticsresequenced:wooly) Gene. If you inject this Gene into yourself, you will be able to be sheared for Wool just like a sheep!
+For example, Sheep have the [Wooly](../.content/genes/wooly) Gene. If you inject this Gene into yourself, you will be able to be sheared for Wool just like a sheep!
 
 ## Getting Genes
 
 Getting Genes is a rather involved process, requiring quite a bit of infrastructure.
 
-First, you'll need a [Scraper](@geneticsresequenced:scraper). This tool can be used on entities to collect [Organic Matter](@geneticsresequenced:organic_matter) from them.
+First, you'll need a [Scraper](../.content/items/scraper). This tool can be used on entities to collect [Organic Matter](../.content/items/organic_matter) from them.
 
 The Organic Matter has the entity type attached to it. This is what decides what Genes you can get from it.
 
-Next, you'll need to process this through a [Cell Analyzer](@geneticsresequenced:cell_analyzer) to get [Cells](@geneticsresequenced:cell). These Cells also contain the entity type.
+Next, you'll need to process this through a [Cell Analyzer](../.content/blocks/machines/cell_analyzer) to get [Cells](../.content/items/cell). These Cells also contain the entity type.
 
 ### Discovering Genes
 
-Process Cells through a [DNA Extractor](@geneticsresequenced:dna_extractor) to get [DNA Helices](@geneticsresequenced:dna_helix).
+Process Cells through a [DNA Extractor](../.content/blocks/machines/dna_extractor) to get [DNA Helices](../.content/items/dna_helix).
 
-To begin with, a DNA Helix knows what entity it came from, but not what Gene it has inside it. To find out, you'll have to process it through a [DNA Decryptor](@geneticsresequenced:dna_decryptor).
+To begin with, a DNA Helix knows what entity it came from, but not what Gene it has inside it. To find out, you'll have to process it through a [DNA Decryptor](../.content/blocks/machines/dna_decryptor).
 
 Each entity type has a set of possible Genes it can provide. Each Gene also has a specific weight, so some Genes are more common than others.
 
-You can find out what Genes and their weights an entity type can provide by using a [Gene Checker](@geneticsresequenced:gene_checker) on it.
+You can find out what Genes and their weights an entity type can provide by using a [Gene Checker](../.content/items/gene_checker) on it.
 
 For example, using it on a Pig will show something along the lines of:
 
@@ -38,7 +38,7 @@ To see what mobs can provide a Gene, you can use [EMI](https://www.curseforge.co
 
 ### Collecting Genes
 
-Get a [Plasmid Infuser](@geneticsresequenced:plasmid_infuser), and place an empty [Plasmid](@geneticsresequenced:plasmid) in its right slot.
+Get a [Plasmid Infuser](../.content/blocks/machines/plasmid_infuser), and place an empty [Plasmid](../.content/items/plasmid) in its right slot.
 
 Plasmids require a certain amount of DNA Points to completely set a Gene. Each Gene requires a different amount of DNA Points.
 
@@ -50,18 +50,18 @@ When the Plasmid has enough DNA Points, it will be marked as complete and can be
 
 ### Injecting Genes
 
-First, get a [Syringe](@geneticsresequenced:syringe) (or, if you want to give the Genes to someone else like a mob, a [Metal Syringe](@geneticsresequenced:metal_syringe)).
+First, get a [Syringe](../.content/items/syringe) (or, if you want to give the Genes to someone else like a mob, a [Metal Syringe](../.content/items/metal_syringe)).
 
 Hold right-click to fill it with blood. Later, you'll put Genes into this blood and inject it back into the blood's owner, and thus give them the Genes.
 
-Before that though, the Syringe is contaminated. Before it can be used, it needs to be sterilized in the [Blood Purifier](@geneticsresequenced:blood_purifier).
+Before that though, the Syringe is contaminated. Before it can be used, it needs to be sterilized in the [Blood Purifier](../.content/blocks/machines/blood_purifier).
 
-Now, place the Syringe in the right slot of a [Plasmid Injector](@geneticsresequenced:plasmid_injector), and a completed Plasmid in the left slot. The Gene carried by the Plasmid will be injected into the blood in the Syringe. A Syringe can hold any amount of Plasmids.
+Now, place the Syringe in the right slot of a [Plasmid Injector](../.content/blocks/machines/plasmid_injector), and a completed Plasmid in the left slot. The Gene carried by the Plasmid will be injected into the blood in the Syringe. A Syringe can hold any amount of Plasmids.
 
 Finally, take the Syringe out and re-inject it back into the blood's owner to give them the Genes!
 
 ## Removing Genes
 
-Genes can be removed using [Anti-Plasmids](@geneticsresequenced:anti_plasmid). These function nearly identically to regular Plasmid, inserted into Syringes via the Plasmid Injector etc.
+Genes can be removed using [Anti-Plasmids](../.content/items/anti_plasmid). These function nearly identically to regular Plasmid, inserted into Syringes via the Plasmid Injector etc.
 
 To choose the Gene to remove, craft the Anti-Plasmid with a completed Plasmid of the Gene you wish to remove.


### PR DESCRIPTION
This probably will break out-of-tree documentation, it's just a demonstration of what a cleaned-up set of .mdx files would look like.

It may require that the .mdx files are post-processed after being copied.  I wrote a python script for it but it could probably be done in a gradle-friendly way.

https://github.com/Berry-Club/Genetics-Resequenced/issues/85